### PR TITLE
bug fix

### DIFF
--- a/src/Anders/PlayerJoinSettings/Main.php
+++ b/src/Anders/PlayerJoinSettings/Main.php
@@ -21,6 +21,7 @@ use pocketmine\Player;
 use pocketmine\plugin\PluginBase;
 use pocketmine\command\Command;
 use pocketmine\command\CommandSender;
+use pocketmine\command\ConsoleCommandSender;
 use pocketmine\event\Listener;
 use pocketmine\event\player\PlayerJoinEvent;
 use pocketmine\event\player\PlayerQuitEvent;


### PR DESCRIPTION
Hi.
This plugin causes an error like this.
`Error: "Class 'Anders\PlayerJoinSettings\consoleCommandSender' not found" (EXCEPTION) in "plugins/PlayerJoinSettings/src/Anders/PlayerJoinSettings/Main" at line 136`
You need more use operator.